### PR TITLE
id carrito producto aniadido en grpc

### DIFF
--- a/grpc_server/carritos_pb2.py
+++ b/grpc_server/carritos_pb2.py
@@ -3,7 +3,6 @@
 # source: carritos.proto
 """Generated protocol buffer code."""
 from google.protobuf import descriptor as _descriptor
-from google.protobuf import descriptor_pool as _descriptor_pool
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
 from google.protobuf import symbol_database as _symbol_database
@@ -15,15 +14,248 @@ _sym_db = _symbol_database.Default()
 import productos_pb2 as productos__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0e\x63\x61rritos.proto\x1a\x0fproductos.proto\"3\n\x07\x43\x61rrito\x12\r\n\x05total\x18\x01 \x01(\x02\x12\x19\n\x11\x63liente_idusuario\x18\x02 \x01(\x05\"\x8c\x01\n\x10Producto_Carrito\x12\x12\n\nidproducto\x18\x01 \x01(\x05\x12\x11\n\tidcarrito\x18\x02 \x01(\x05\x12\x10\n\x08\x63\x61ntidad\x18\x03 \x01(\x05\x12\x10\n\x08subtotal\x18\x04 \x01(\x02\x12\x0e\n\x06nombre\x18\x05 \x01(\t\x12\x0e\n\x06precio\x18\x06 \x01(\x02\x12\r\n\x05total\x18\x07 \x01(\x02\"3\n\x0fPutTotalCarrito\x12\x11\n\tidcarrito\x18\x01 \x01(\x05\x12\r\n\x05total\x18\x02 \x01(\x02\"\x17\n\tIdCarrito\x12\n\n\x02id\x18\x01 \x01(\x05\"\"\n\x0fResponseCarrito\x12\x0f\n\x07mensaje\x18\x01 \x01(\t2\x95\x02\n\x08\x43\x61rritos\x12$\n\x0c\x43rearCarrito\x12\x08.Carrito\x1a\n.IdCarrito\x12<\n\x13\x41gregarItemsCarrito\x12\x11.Producto_Carrito\x1a\x10.ResponseCarrito(\x01\x12;\n\x18TraerCarritosByIdUsuario\x12\n.IdUsuario\x1a\x11.Producto_Carrito0\x01\x12*\n\x10TraerCarritoById\x12\n.IdCarrito\x1a\x08.Carrito0\x01\x12<\n\x16\x41\x63tualizarTotalCarrito\x12\x10.PutTotalCarrito\x1a\x10.ResponseCarritob\x06proto3')
+DESCRIPTOR = _descriptor.FileDescriptor(
+  name='carritos.proto',
+  package='',
+  syntax='proto3',
+  serialized_options=None,
+  create_key=_descriptor._internal_create_key,
+  serialized_pb=b'\n\x0e\x63\x61rritos.proto\x1a\x0fproductos.proto\"3\n\x07\x43\x61rrito\x12\r\n\x05total\x18\x01 \x01(\x02\x12\x19\n\x11\x63liente_idusuario\x18\x02 \x01(\x05\"\xa7\x01\n\x10Producto_Carrito\x12\x12\n\nidproducto\x18\x01 \x01(\x05\x12\x11\n\tidcarrito\x18\x02 \x01(\x05\x12\x10\n\x08\x63\x61ntidad\x18\x03 \x01(\x05\x12\x10\n\x08subtotal\x18\x04 \x01(\x02\x12\x0e\n\x06nombre\x18\x05 \x01(\t\x12\x0e\n\x06precio\x18\x06 \x01(\x02\x12\r\n\x05total\x18\x07 \x01(\x02\x12\x19\n\x11idproductocarrito\x18\x08 \x01(\x05\"3\n\x0fPutTotalCarrito\x12\x11\n\tidcarrito\x18\x01 \x01(\x05\x12\r\n\x05total\x18\x02 \x01(\x02\"\x17\n\tIdCarrito\x12\n\n\x02id\x18\x01 \x01(\x05\"\"\n\x0fResponseCarrito\x12\x0f\n\x07mensaje\x18\x01 \x01(\t2\x95\x02\n\x08\x43\x61rritos\x12$\n\x0c\x43rearCarrito\x12\x08.Carrito\x1a\n.IdCarrito\x12<\n\x13\x41gregarItemsCarrito\x12\x11.Producto_Carrito\x1a\x10.ResponseCarrito(\x01\x12;\n\x18TraerCarritosByIdUsuario\x12\n.IdUsuario\x1a\x11.Producto_Carrito0\x01\x12*\n\x10TraerCarritoById\x12\n.IdCarrito\x1a\x08.Carrito0\x01\x12<\n\x16\x41\x63tualizarTotalCarrito\x12\x10.PutTotalCarrito\x1a\x10.ResponseCarritob\x06proto3'
+  ,
+  dependencies=[productos__pb2.DESCRIPTOR,])
 
 
 
-_CARRITO = DESCRIPTOR.message_types_by_name['Carrito']
-_PRODUCTO_CARRITO = DESCRIPTOR.message_types_by_name['Producto_Carrito']
-_PUTTOTALCARRITO = DESCRIPTOR.message_types_by_name['PutTotalCarrito']
-_IDCARRITO = DESCRIPTOR.message_types_by_name['IdCarrito']
-_RESPONSECARRITO = DESCRIPTOR.message_types_by_name['ResponseCarrito']
+
+_CARRITO = _descriptor.Descriptor(
+  name='Carrito',
+  full_name='Carrito',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='total', full_name='Carrito.total', index=0,
+      number=1, type=2, cpp_type=6, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='cliente_idusuario', full_name='Carrito.cliente_idusuario', index=1,
+      number=2, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=35,
+  serialized_end=86,
+)
+
+
+_PRODUCTO_CARRITO = _descriptor.Descriptor(
+  name='Producto_Carrito',
+  full_name='Producto_Carrito',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='idproducto', full_name='Producto_Carrito.idproducto', index=0,
+      number=1, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='idcarrito', full_name='Producto_Carrito.idcarrito', index=1,
+      number=2, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='cantidad', full_name='Producto_Carrito.cantidad', index=2,
+      number=3, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='subtotal', full_name='Producto_Carrito.subtotal', index=3,
+      number=4, type=2, cpp_type=6, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='nombre', full_name='Producto_Carrito.nombre', index=4,
+      number=5, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='precio', full_name='Producto_Carrito.precio', index=5,
+      number=6, type=2, cpp_type=6, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='total', full_name='Producto_Carrito.total', index=6,
+      number=7, type=2, cpp_type=6, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='idproductocarrito', full_name='Producto_Carrito.idproductocarrito', index=7,
+      number=8, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=89,
+  serialized_end=256,
+)
+
+
+_PUTTOTALCARRITO = _descriptor.Descriptor(
+  name='PutTotalCarrito',
+  full_name='PutTotalCarrito',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='idcarrito', full_name='PutTotalCarrito.idcarrito', index=0,
+      number=1, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='total', full_name='PutTotalCarrito.total', index=1,
+      number=2, type=2, cpp_type=6, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=258,
+  serialized_end=309,
+)
+
+
+_IDCARRITO = _descriptor.Descriptor(
+  name='IdCarrito',
+  full_name='IdCarrito',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='id', full_name='IdCarrito.id', index=0,
+      number=1, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=311,
+  serialized_end=334,
+)
+
+
+_RESPONSECARRITO = _descriptor.Descriptor(
+  name='ResponseCarrito',
+  full_name='ResponseCarrito',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='mensaje', full_name='ResponseCarrito.mensaje', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=336,
+  serialized_end=370,
+)
+
+DESCRIPTOR.message_types_by_name['Carrito'] = _CARRITO
+DESCRIPTOR.message_types_by_name['Producto_Carrito'] = _PRODUCTO_CARRITO
+DESCRIPTOR.message_types_by_name['PutTotalCarrito'] = _PUTTOTALCARRITO
+DESCRIPTOR.message_types_by_name['IdCarrito'] = _IDCARRITO
+DESCRIPTOR.message_types_by_name['ResponseCarrito'] = _RESPONSECARRITO
+_sym_db.RegisterFileDescriptor(DESCRIPTOR)
+
 Carrito = _reflection.GeneratedProtocolMessageType('Carrito', (_message.Message,), {
   'DESCRIPTOR' : _CARRITO,
   '__module__' : 'carritos_pb2'
@@ -59,20 +291,71 @@ ResponseCarrito = _reflection.GeneratedProtocolMessageType('ResponseCarrito', (_
   })
 _sym_db.RegisterMessage(ResponseCarrito)
 
-_CARRITOS = DESCRIPTOR.services_by_name['Carritos']
-if _descriptor._USE_C_DESCRIPTORS == False:
 
-  DESCRIPTOR._options = None
-  _CARRITO._serialized_start=35
-  _CARRITO._serialized_end=86
-  _PRODUCTO_CARRITO._serialized_start=89
-  _PRODUCTO_CARRITO._serialized_end=229
-  _PUTTOTALCARRITO._serialized_start=231
-  _PUTTOTALCARRITO._serialized_end=282
-  _IDCARRITO._serialized_start=284
-  _IDCARRITO._serialized_end=307
-  _RESPONSECARRITO._serialized_start=309
-  _RESPONSECARRITO._serialized_end=343
-  _CARRITOS._serialized_start=346
-  _CARRITOS._serialized_end=623
+
+_CARRITOS = _descriptor.ServiceDescriptor(
+  name='Carritos',
+  full_name='Carritos',
+  file=DESCRIPTOR,
+  index=0,
+  serialized_options=None,
+  create_key=_descriptor._internal_create_key,
+  serialized_start=373,
+  serialized_end=650,
+  methods=[
+  _descriptor.MethodDescriptor(
+    name='CrearCarrito',
+    full_name='Carritos.CrearCarrito',
+    index=0,
+    containing_service=None,
+    input_type=_CARRITO,
+    output_type=_IDCARRITO,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='AgregarItemsCarrito',
+    full_name='Carritos.AgregarItemsCarrito',
+    index=1,
+    containing_service=None,
+    input_type=_PRODUCTO_CARRITO,
+    output_type=_RESPONSECARRITO,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='TraerCarritosByIdUsuario',
+    full_name='Carritos.TraerCarritosByIdUsuario',
+    index=2,
+    containing_service=None,
+    input_type=productos__pb2._IDUSUARIO,
+    output_type=_PRODUCTO_CARRITO,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='TraerCarritoById',
+    full_name='Carritos.TraerCarritoById',
+    index=3,
+    containing_service=None,
+    input_type=_IDCARRITO,
+    output_type=_CARRITO,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='ActualizarTotalCarrito',
+    full_name='Carritos.ActualizarTotalCarrito',
+    index=4,
+    containing_service=None,
+    input_type=_PUTTOTALCARRITO,
+    output_type=_RESPONSECARRITO,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+])
+_sym_db.RegisterServiceDescriptor(_CARRITOS)
+
+DESCRIPTOR.services_by_name['Carritos'] = _CARRITOS
+
 # @@protoc_insertion_point(module_scope)

--- a/grpc_server/protobufs/carritos.proto
+++ b/grpc_server/protobufs/carritos.proto
@@ -14,6 +14,7 @@ message Producto_Carrito {
     string nombre = 5;
     float precio = 6;
     float total = 7;
+    int32 idproductocarrito = 8;
 }
 
 message PutTotalCarrito {

--- a/grpc_server/server.py
+++ b/grpc_server/server.py
@@ -122,14 +122,40 @@ class ProductoUsuarios(ProductosServicer):
             if row.url_foto5 is not None:
                 fotos.append(row.url_foto5)
             
+            result = ProductoGet(
+                    nombre = row.nombre, 
+                    descripcion = row.descripcion, 
+                    categoria = row.categoria, 
+                    precio = row.precio, 
+                    cantidad_disponible = row.cantidad_disponible, 
+                    fecha_publicacion = row.fecha_publicacion, 
+                    publicador = row.username,
+                    url_fotos = fotos)
+
             #traer campos de subasta y aniadirlos al return
             if row.esSubasta:
-                pass
-            return ProductoGet(nombre = row.nombre, descripcion = row.descripcion, categoria = row.categoria, precio = row.precio, 
-            cantidad_disponible = row.cantidad_disponible, fecha_publicacion = row.fecha_publicacion, publicador = row.username,
-            url_fotos = fotos)
+                query = (f"select s.preciofinal as preciofinal, s.ultimapuja as ultimapuja, s.fechafin as fechafin from subasta s where s.idproducto= '{request.idproducto}'")
+                cursor.execute(query)
+                subasta = cursor.fetchone()
+
+                timestampFin = Timestamp()
+                timestampFin.FromDatetime(subasta.fechafin)
+                timestampPuja = Timestamp()
+                timestampPuja.FromDatetime(subasta.ultimapuja)
+
+                result = ProductoGet(
+                    nombre = row.nombre, 
+                    descripcion = row.descripcion, 
+                    categoria = row.categoria,
+                    precio = subasta.preciofinal, 
+                    cantidad_disponible = row.cantidad_disponible, 
+                    fecha_publicacion = row.fecha_publicacion, 
+                    publicador = row.username,
+                    fecha_fin = timestampFin,
+                    fecha_inicio = timestampPuja,
+                    url_fotos = fotos)
         else:
-            return ProductoGet()
+            return result
 
 
     def TraerProductos(self, request, context):
@@ -166,7 +192,7 @@ class ProductoUsuarios(ProductosServicer):
                 " s.fechafin as fechafin, s.ultimapuja as ultimapuja ,s.preciofinal as preciofinal from producto p "
                 " inner join tipo_categoria c on p.idtipocategoria = c.idtipocategoria "
                 " inner join usuario u on p.publicador_idusuario = u.idusuario "
-                " inner join subasta son s.idproducto = p.idproducto where p.esSubasta = 1 ")
+                " inner join subasta s on s.idproducto = p.idproducto where p.esSubasta = 1 ")
         cursor.execute(query)
         records = cursor.fetchall()
         for row in records:
@@ -304,7 +330,7 @@ class CarritoProductos(CarritosServicer):
                               host='localhost', port='3306',
                               database='retroshop')
         cursor = cnx.cursor(named_tuple=True)
-        query = (f"SELECT c.idcarrito,c.total, pc.idproducto_carrito, pc.cantidad,pc.subtotal,p.idproducto, "+
+        query = (f"SELECT c.idcarrito,c.total, pc.idproducto_carrito as productocarrito, pc.cantidad,pc.subtotal,p.idproducto, "+
         "p.precio, p.nombre FROM carrito c "+
         f"inner join producto_carrito pc on c.idcarrito=pc.idcarrito "+
         f"inner join producto p on p.idproducto=pc.idproducto where c.cliente_idusuario = '{request.idusuario}'")
@@ -312,7 +338,7 @@ class CarritoProductos(CarritosServicer):
         records = cursor.fetchall()
         for row in records:
             yield Producto_Carrito(idproducto = row.idproducto, idcarrito = row.idcarrito, cantidad = row.cantidad, 
-            subtotal = row.subtotal, nombre = row.nombre, precio = row.precio, total = row.total)
+            subtotal = row.subtotal, nombre = row.nombre, precio = row.precio, total = row.total, idproductocarrito = row.productocarrito)
 
 
     def ActualizarTotalCarrito(self, request, context):


### PR DESCRIPTION
Metodos que traigan productos que sean subasta ahora traen los campos de fecha en vez de estar vacios.
Un carrito puede tener muchos carritos_productos. El id de carrito_producto se aniade a los mensajes de carrito en grpc.